### PR TITLE
Fix missing output when no release has been made

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -o pipefail
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging


### PR DESCRIPTION
Commit 05ed406 added "set -o pipefail" in assets/check, but this creates
a tiny side effect:

When no revisions exist yet, "grep -i 'deployed'" returns 1,
and with pipefail enabled, the whole pipe returns 1.
At this point, the script immediately exits (due to "set -e"), and the
output in line 57 will never happen, confusing the user.